### PR TITLE
Fixes compile issues in 'other interesting things' tests

### DIFF
--- a/src/test/scala/com/intenthq/doobie/DooSpec.scala
+++ b/src/test/scala/com/intenthq/doobie/DooSpec.scala
@@ -109,19 +109,20 @@ class DooSpec extends DbSpecification {
   }
 
   "other interesting things" >> {
-//    import doobie.imports._
+//    import doobie.implicits._
+//    import doobie.util.invariant.{UnexpectedContinuation, UnexpectedEnd}
 
     "asking for a single result if the query returns more than one row returns an error" >> {
 //      Doo.Q.companyCaseClasses.option.transact(dbContext.xa).attempt
-//        .unsafePerformIO must beLeft(UnexpectedContinuation)
+//        .unsafeRunSync must beLeft(UnexpectedContinuation)
 //      Doo.Q.companyCaseClasses.unique.transact(dbContext.xa).attempt
-//        .unsafePerformIO must beLeft(UnexpectedContinuation)
+//        .unsafeRunSync must beLeft(UnexpectedContinuation)
       pending
     }
 
     "asking for a unique result if the query returns an empty resultset returns an error" >> {
 //      Doo.Q.companyCaseClass(CompanyId(-1000)).unique.transact(dbContext.xa).attempt
-//        .unsafePerformIO must beLeft(UnexpectedEnd)
+//        .unsafeRunSync must beLeft(UnexpectedEnd)
       pending
     }
 


### PR DESCRIPTION
Hi!

Thanks for the workshop at JBCNConf yesterday, I learned a lot from it. We use Slick at work, and I wanted to see what Doobie was all about. I have to say, I like it a lot more than I thought I would.

I tried to do the 'other interesting things' tests, and they didn't compile for me. So, here's a PR where the compile issues are fixed (assuming the student has implemented `Q.companyCaseClass` and `Q.companyCaseClasses`). All my tests are non-pending and green now :).

Cheers,
Jan
